### PR TITLE
fix: 🐛 Prettier の trailingComma に無効な値を設定していたので修正した

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   tabWidth: 2,
   singleQuote: true,
-  trailingComma: 'es6',
+  trailingComma: 'es5',
   semi: false,
 }


### PR DESCRIPTION
Error: Invalid trailingComma value. Expected "all", "es5" or "none", but
received "es6".
